### PR TITLE
Abandon extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-      "contao/core-bundle": "^4.4"
+      "contao/core-bundle": ">=4.4 <4.13"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0"

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,8 @@
 # Improve the restore section of Contao Open Source CMS
 
+> 📢This extension was originally developed to *research out in the open* how to improve the Contao core restore module. After many years of not working on this topic, [we improved the undo module in Contao 4.13](https://github.com/contao/contao/pull/3498). Since this is the latest LTS now we recommend you to upgrade your installations and enjoy the revamped undo module. This extension is therefore obsolete. 
+
 This extension improves the restore section of Contao by providing more semantic information regarding the deleted elements. The existing core view only provides rather technical information, i.e. the table name the deleted element was stored in and the corresponding sql query. This might be a hurdle to many editors.
-
-We see this extension solely as a research tool. As soon we come up with a solid solution, we aim for a PR to the Contao core.
-
-*Any help or feedback is very much welcome*
 
 ![Screenshot of the improved restore section](contao-undo-screenshot.jpg?raw=true)
 


### PR DESCRIPTION
This extension is not needed anymore, as the revamped restore module was shipped with Contao 4.13. If you have not updated your installations, we highly recommend it. 4.13 is the latest LTS anyways 🙂 

For more information see the [lengthy pull request](https://github.com/contao/contao/pull/3498) 😎 

Enjoy the new restore module 🚀 